### PR TITLE
Add password visibility toggle on Register page

### DIFF
--- a/src/components/shared/Navbar.jsx
+++ b/src/components/shared/Navbar.jsx
@@ -6,7 +6,7 @@ import avatar from "../../assets/default-avatar.png";
 import { logoutUser } from "../../redux/auth/authSlice";
 
 const Navbar = () => {
-  const { user, loading } = useSelector((state) => state.auth);
+  const { user } = useSelector((state) => state.auth);
   const dispatch = useDispatch();
   const navigate = useNavigate();
 

--- a/src/page/Authentication/Register.jsx
+++ b/src/page/Authentication/Register.jsx
@@ -1,17 +1,20 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import registerImg from "../../assets/register.jpeg";
 import { FcGoogle } from "react-icons/fc";
+import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
 import { useForm } from "react-hook-form";
 import Swal from "sweetalert2";
 import { useDispatch, useSelector } from "react-redux";
 import { registerUser } from "../../redux/auth/authSlice";
 
-
 const Register = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { loading } = useSelector((state) => state.auth);
+
+  // Added state for password visibility
+  const [showPassword, setShowPassword] = useState(false);
 
   const {
     register,
@@ -27,7 +30,7 @@ const Register = () => {
         userInfo: data,
       })
     );
-  
+
     if (resultAction.meta.requestStatus === "fulfilled") {
       Swal.fire({
         position: "center",
@@ -41,7 +44,7 @@ const Register = () => {
       console.error("Sign up failed:", resultAction.payload);
     }
   };
-  
+
   return (
     <div className="flex justify-center items-center min-h-screen p-4">
       <div className="flex flex-col lg:flex-row max-w-4xl w-full  rounded-md  overflow-hidden">
@@ -107,22 +110,35 @@ const Register = () => {
                 <label htmlFor="password" className="text-sm mb-2 block">
                   Password
                 </label>
-                <input
-                  type="password"
-                  id="password"
-                  {...register("password", {
-                    required: "Password is required",
-                    minLength: { value: 6, message: "Minimum 6 characters" },
-                    // maxLength: { value: 20, message: "Maximum 20 characters" },
-                    // pattern: {
-                    //   value: /(?=.*[A-Z])(?=.*[!@#$&*])(?=.*[0-9])(?=.*[a-z])/,
-                    //   message:
-                    //     "Must contain upper, lower, number & special char",
-                    // },
-                  })}
-                  placeholder="*******"
-                  className="w-full px-3 py-2 border-2 rounded-md border-gray-300 focus:border-[#f5b754] focus:outline-none bg-gray-200 text-gray-900"
-                />
+                <div className="relative">
+                  <input
+                    type={showPassword ? "text" : "password"}
+                    id="password"
+                    {...register("password", {
+                      required: "Password is required",
+                      minLength: { value: 6, message: "Minimum 6 characters" },
+                      // maxLength: { value: 20, message: "Maximum 20 characters" },
+                      // pattern: {
+                      //   value: /(?=.*[A-Z])(?=.*[!@#$&*])(?=.*[0-9])(?=.*[a-z])/,
+                      //   message:
+                      //     "Must contain upper, lower, number & special char",
+                      // },
+                    })}
+                    placeholder="Enter Your Password Here"
+                    className="w-full px-3 py-2 border-2 rounded-md border-gray-300 focus:border-[#f5b754] focus:outline-none bg-gray-200 text-gray-900"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-700"
+                  >
+                    {showPassword ? (
+                      <AiOutlineEyeInvisible size={20} />
+                    ) : (
+                      <AiOutlineEye size={20} />
+                    )}
+                  </button>
+                </div>
                 {errors.password && (
                   <p className="text-red-500 text-xs mt-1">
                     {errors.password.message}
@@ -131,12 +147,6 @@ const Register = () => {
               </div>
             </div>
             <div>
-              {/* <button
-                type="submit"
-                className="bgOrange hover:bg-[#f5b754ef] w-full rounded-md py-3 text-white"
-              >
-                Continue
-              </button> */}
               <button
                 type="submit"
                 className={`w-full py-2 mt-4 rounded-md bg-[#f5b754] text-white ${
@@ -162,7 +172,7 @@ const Register = () => {
             <p>Continue with Google</p>
           </div>
           <p className="px-6 text-sm text-center text-gray-200">
-            Don&apos;t have an account yet?{" "}
+            Don't have an account yet?{" "}
             <Link
               to="/login"
               className="hover:underline hover:text-[#f5b754ef] text-gray-200"


### PR DESCRIPTION
### 📌 Changes Made:
- Added password visibility toggle using `useState` hook.
- Integrated `AiOutlineEye` and `AiOutlineEyeInvisible` icons for password visibility toggle.
- Ensured accessibility and responsiveness.
- Improved user experience by allowing password visibility control.

### 🚀 Reason for Change:
- To enhance user experience during password entry.
- Provide users with an option to check their password before submitting.

### ✅ Testing Done:
- Checked responsiveness on different screen sizes.
- Verified password visibility toggle works as expected.
- Ensured no errors or console warnings.
![Add password visibility toggle on Register page](https://github.com/user-attachments/assets/4370aee9-1893-4f59-ad29-3904fb9c5dff)
![Add password visibility toggle on Register page Show](https://github.com/user-attachments/assets/2222b4b3-c1dd-4d4c-b1df-8cf112e11329)
