### PR TITLE
Update Google Login to Include Last Login Time

### DIFF
--- a/src/page/Authentication/GoogleLogIn.jsx
+++ b/src/page/Authentication/GoogleLogIn.jsx
@@ -26,8 +26,17 @@ const GoogleLogIn = () => {
         photoURL: user.photoURL,
       };
 
-      // Sending user data to the server
-      await axiosPublic.post("/add-user", userData);
+      // Check if user exists, if not add them, then update last login
+      const existingUserResponse = await axiosPublic.post(
+        "/add-user",
+        userData
+      );
+      if (existingUserResponse.data.message !== "User already exists") {
+        console.log("New user added:", existingUserResponse.data);
+      }
+
+      // Update last login time
+      await axiosPublic.patch("/update-last-login", { email: user.email });
 
       // Setting up users in Redux
       dispatch(setUser(userData));


### PR DESCRIPTION
### Overview
This PR updates the Google login functionality to ensure the `lastLogin` field is updated in the database every time a user logs in with Google, addressing the issue where it was only being set for new users.

### Changes Made
- **Added `lastLogin` Update**: Included a PATCH request to `/update-last-login` endpoint after the `/add-user` POST request in the `GoogleLogIn` component.
- **User Existence Check**: Retained the `/add-user` POST request to handle new user registration and added logic to log a message if a new user is added.
- **Error Handling**: Kept existing error handling intact to display errors via SweetAlert2 if the login process fails.

### Why These Changes?
Previously, the `lastLogin` field was not being updated for subsequent Google logins because only the `/add-user` endpoint was called, which only adds new users and does not update existing ones. Adding the `/update-last-login` call ensures consistency with the email/password login flow, where `lastLogin` is updated on every login.


### Testing
- Tested Google login for a new user: Verified that user data is added to the database with `creationDate` and `lastLogin` set.
- Tested Google login for an existing user: Confirmed that `lastLogin` updates with the current timestamp in the Asia/Dhaka timezone.
- Tested error scenarios: Simulated network failure to ensure error messages display correctly via Swal.
