### PR TITLE
Add forget password functionality with reset email form and routing

### DIFF
--- a/src/Router/Router.jsx
+++ b/src/Router/Router.jsx
@@ -22,6 +22,7 @@ import UpdateProfile from "../DeahBoardPage/UpdateProfile/UpdateProfile";
 import CarDetails from "../components/common/CarDetails/CarDetails";
 import NumberCard from "../components/shared/card/NumberCard";
 import BookAuto from "../page/services/BookAuto";
+import ForgetPassword from "../page/Authentication/ForgetPassword";
 
 export const router = createBrowserRouter([
   {
@@ -95,5 +96,9 @@ export const router = createBrowserRouter([
   {
     path: "/login",
     element: <LogIn />,
+  },
+  {
+    path: "/forget-password",
+    element: <ForgetPassword />,
   },
 ]);

--- a/src/page/Authentication/ForgetPassword.jsx
+++ b/src/page/Authentication/ForgetPassword.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { sendPasswordResetEmail } from "firebase/auth";
+import auth from "../../firebase/firebase.config";
+import { useNavigate } from "react-router-dom";
+import Swal from "sweetalert2";
+
+const ForgetPassword = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+  const navigate = useNavigate();
+
+  const onSubmit = async (data) => {
+    try {
+      await sendPasswordResetEmail(auth, data.email);
+      Swal.fire({
+        icon: "success",
+        title: "Success!",
+        text: "Password reset email sent. Please check your inbox.",
+        confirmButtonColor: "#f5b754",
+      }).then(() => {
+        navigate("/login");
+      });
+    } catch (error) {
+      Swal.fire({
+        icon: "error",
+        title: "Oops...",
+        text: error.message,
+        confirmButtonColor: "#f5b754",
+      });
+    }
+  };
+
+  return (
+    <div className="flex justify-center items-center min-h-screen">
+      <div className="w-full max-w-sm p-6 bg-white rounded-md shadow-md">
+        <h2 className="text-2xl font-bold text-center text-gray-800 mb-4">
+          Forget Password
+        </h2>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="block mb-1 text-gray-600 text-sm">
+              Email address
+            </label>
+            <input
+              type="email"
+              id="email"
+              {...register("email", { required: "Email is required" })}
+              placeholder="Enter Your Email"
+              className="w-full px-3 py-2 border-2 rounded-md text-gray-500 border-gray-300 focus:border-[#f5b754] focus:outline-none"
+            />
+            {errors.email && (
+              <p className="text-red-500 text-sm">{errors.email.message}</p>
+            )}
+          </div>
+          <div>
+            <button
+              type="submit"
+              className="bg-[#f5b754] w-full rounded-md py-3 text-white hover:bg-[#f5b754ef]"
+            >
+              Send Reset Email
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ForgetPassword;

--- a/src/page/Authentication/LogIn.jsx
+++ b/src/page/Authentication/LogIn.jsx
@@ -97,9 +97,12 @@ const Login = () => {
                 )}
               </div>
               <div className="text-right">
-                <a href="#" className="text-sm hover:underline text-[#f5b754]">
+                <Link
+                  to="/forget-password"
+                  className="text-sm hover:underline text-[#f5b754]"
+                >
                   Forgot password?
-                </a>
+                </Link>
               </div>
             </div>
 


### PR DESCRIPTION
- Added a new `ForgetPassword` component to allow users to reset their password via email.
- Integrated Firebase `sendPasswordResetEmail` for sending the reset link.
- Used `react-hook-form` for form validation.
- Added `SweetAlert2` for showing success/error feedback.
- Added routing for `/forget-password`.
- Linked "Forgot Password?" on the login page to the new route.

### Test Instructions:
1. Go to the login page.
2. Click on "Forgot password?"
3. Submit a valid email to receive the password reset link.
4. Check if the alert appears and redirects back to login after confirmation.

### Screenshots
![Forget Password page](https://github.com/user-attachments/assets/5965c40a-5e42-46c8-bb00-2d11f0b9c219)
=>
![After forget mail sent](https://github.com/user-attachments/assets/bdd2efe1-68c6-461b-93e7-cc48929f33ac)
