### PR TITLE
Include default booking metadata in BookingModal submission

### DIFF
--- a/src/components/common/Modal/BookingModal.jsx
+++ b/src/components/common/Modal/BookingModal.jsx
@@ -66,6 +66,9 @@ const BookingModal = ({ isOpen, onClose, car }) => {
         pickUpDate: data.pickUpDate,
         returnDate: data.returnDate,
         additionalNote: data.additionalNote,
+        paymentStatus: "Pending",
+        tripStatus: "Pending",
+        driver: "Not Assigned",
       };
 
       const response = await axiosSecure.post("/book-auto", bookingData);


### PR DESCRIPTION
### Summary:
Added three new default fields to the booking payload to support future enhancements in the booking management system.

### Changes:
- `paymentStatus`: set to `"Pending"` by default
- `tripStatus`: set to `"Pending"` by default
- `driver`: set to `"Not Assigned"` by default

### Reason:
These fields will be useful for:
- Tracking the current state of the payment and trip.
- Assigning drivers later in the booking workflow.

No changes were made to the UI.