### PR TITLE
Display driver assigned trips in StartTrip component

### DIFF
--- a/src/DeahBoardPage/Driver/StartTrip.jsx
+++ b/src/DeahBoardPage/Driver/StartTrip.jsx
@@ -12,29 +12,24 @@ const StartTrip = () => {
   const driverEmail = currentUser?.email;
   const axiosSecure = useAxiosSecure();
   const axiosPublic = useAxiosPublic();
-  const trip = {
-    carName: "Toyota Corolla",
-    carImage:
-      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcROywEwo4S2_bitDGhl3NArx4qrbpUjtiYPMw&s",
-    pickupLocation: "Dhaka City Center",
-    startTime: "2025-04-10 10:00 AM",
-    route: "Dhaka → Chattogram",
-  };
-
   const [availableTrips, setAvailableTrips] = useState([]);
+  const [assignedTrips, setAssignedTrips] = useState([]);
 
+  // Fetch both available and assigned trips
   useEffect(() => {
-    const fetchAvailableTrips = async () => {
+    const fetchData = async () => {
       try {
-        const response = await axiosPublic.get(
-          `/available-trips?email=${driverEmail}`
-        );
-        setAvailableTrips(response.data);
+        const [availableResponse, assignedResponse] = await Promise.all([
+          axiosPublic.get(`/available-trips?email=${driverEmail}`),
+          axiosPublic.get(`/driver-assignments/${driverEmail}`),
+        ]);
+        setAvailableTrips(availableResponse.data);
+        setAssignedTrips(assignedResponse.data);
       } catch (error) {
-        console.error("Failed to fetch available trips:", error);
+        console.error("Failed to fetch data:", error);
       }
     };
-    fetchAvailableTrips();
+    fetchData();
   }, [axiosPublic, driverEmail]);
 
   const handleStartTrip = () => {
@@ -86,10 +81,12 @@ const StartTrip = () => {
         throw new Error("Driver email not found. Please log in again.");
       }
       await axiosSecure.post(`/pick-trip/${id}`, { driverEmail });
-      const response = await axiosPublic.get(
-        `/available-trips?email=${driverEmail}`
-      );
-      setAvailableTrips(response.data);
+      const [availableResponse, assignedResponse] = await Promise.all([
+        axiosPublic.get(`/available-trips?email=${driverEmail}`),
+        axiosPublic.get(`/driver-assignments/${driverEmail}`),
+      ]);
+      setAvailableTrips(availableResponse.data);
+      setAssignedTrips(assignedResponse.data);
       Swal.fire({
         title: "Success!",
         text: "Trip Picked Successfully!",
@@ -118,10 +115,12 @@ const StartTrip = () => {
         throw new Error("Driver email not found. Please log in again.");
       }
       await axiosSecure.post(`/cancel-trip/${id}`, { driverEmail });
-      const response = await axiosPublic.get(
-        `/available-trips?email=${driverEmail}`
-      );
-      setAvailableTrips(response.data);
+      const [availableResponse, assignedResponse] = await Promise.all([
+        axiosPublic.get(`/available-trips?email=${driverEmail}`),
+        axiosPublic.get(`/driver-assignments/${driverEmail}`),
+      ]);
+      setAvailableTrips(availableResponse.data);
+      setAssignedTrips(assignedResponse.data);
       Swal.fire({
         title: "Success!",
         text: "Trip canceled successfully!",
@@ -146,41 +145,60 @@ const StartTrip = () => {
   return (
     <div className="pb-10">
       <Header title="Trip Started! 🚗" />
-      <h2 className="text-3xl font-bold text-center text-[#f5b754] mb-8 flex items-center justify-center gap-2 pt-4">
-        <FaRoute /> Start Your Trip
-      </h2>
 
-      <div className="bg-[#1B1B1B] rounded-lg shadow-lg p-6 grid grid-cols-1 md:grid-cols-2 gap-8 px-4">
-        {/* Car Image */}
-        <div>
-          <img
-            src={trip.carImage}
-            alt={trip.carName}
-            className="w-full h-60 object-cover rounded-xl"
-          />
-        </div>
-
-        {/* Trip Info */}
-        <div className="space-y-4">
-          <h3 className="text-2xl font-semibold">{trip.carName}</h3>
-          <p className="flex items-center gap-2">
-            <FaClock className="text-[#f5b754]" /> Start Time: {trip.startTime}
+      {/* Assigned Trips Section */}
+      <div className="mt-8">
+        <h2 className="text-3xl font-bold text-center text-[#f5b754] mb-8 flex items-center justify-center gap-2 pt-4">
+          <FaRoute /> Your Assigned Trips
+        </h2>
+        {assignedTrips.length === 0 ? (
+          <p className="text-center text-gray-500">
+            You have no assigned trips.
           </p>
-          <p className="flex items-center gap-2">
-            <FaMapMarkedAlt className="text-[#f5b754]" /> Pickup:{" "}
-            {trip.pickupLocation}
-          </p>
-          <p className="flex items-center gap-2">
-            <FaRoute className="text-[#f5b754]" /> Route: {trip.route}
-          </p>
-
-          <button
-            onClick={handleStartTrip}
-            className="mt-6 w-full bg-[#f5b754] hover:bg-yellow-500 text-white font-semibold py-3 rounded-lg transition duration-300"
-          >
-            Confirm & Start Trip
-          </button>
-        </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {assignedTrips.map((trip) => (
+              <div
+                key={trip._id}
+                className="bg-[#1B1B1B] rounded-lg shadow-lg p-6 grid grid-cols-1 md:grid-cols-2 gap-8"
+              >
+                {/* Car Image */}
+                <div>
+                  <img
+                    src={
+                      trip.carImage ||
+                      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcROywEwo4S2_bitDGhl3NArx4qrbpUjtiYPMw&s"
+                    }
+                    alt={trip.carName}
+                    className="w-full h-60 object-cover rounded-xl"
+                  />
+                </div>
+                {/* Trip Info */}
+                <div className="space-y-4">
+                  <h3 className="text-2xl font-semibold">{trip.carName}</h3>
+                  <p className="flex items-center gap-2">
+                    <FaClock className="text-[#f5b754]" /> Start Time:{" "}
+                    {trip.pickUpDate}
+                  </p>
+                  <p className="flex items-center gap-2">
+                    <FaMapMarkedAlt className="text-[#f5b754]" /> Pickup:{" "}
+                    {trip.pickUpLocation}
+                  </p>
+                  <p className="flex items-center gap-2">
+                    <FaRoute className="text-[#f5b754]" /> Route:{" "}
+                    {trip.pickUpLocation} → {trip.dropOffLocation}
+                  </p>
+                  <button
+                    onClick={() => handleStartTrip(trip._id)}
+                    className="mt-6 w-full bg-[#f5b754] hover:bg-yellow-500 text-white font-semibold py-3 rounded-lg transition duration-300"
+                  >
+                    Confirm & Start Trip
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
 
       {/* Available Trips Section */}


### PR DESCRIPTION
### Summary
This PR modifies the `StartTrip` component to display trips picked by the driver from the `driverAssignments` collection, replacing the hardcoded trip data. The pick and cancel functionalities for available trips remain unchanged.

### Changes
#### Backend
- Added a new GET endpoint `/driver-assignments/:email` to fetch trips from `driverAssignments` where `tripStatus` is "Booked" for the specified driver email.
- Optionally added `carImage` to the assignment document in `/pick-trip/:id` (assumes `carImage` exists in bookings).

#### Frontend
- Added `assignedTrips` state in `StartTrip` component.
- Updated `useEffect` to fetch both available and assigned trips.
- Replaced hardcoded trip section with a dynamic "Your Assigned Trips" section that maps over `assignedTrips`.
- Updated `handlePickTrip` and `handleCancelTrip` to refetch both trip lists after actions.
- Kept the "Available Trips" section intact with functional "Pick" and "Cancel" buttons.

### Impact
- Drivers now see their picked trips in the "Start Your Trip" section instead of static data.
- The UI updates correctly after picking or canceling trips.